### PR TITLE
Add "ROS 2 Workspace Test" Sub-Action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [main]
 jobs:
-  individual-setup-build:
-    name: Individual Setup and build
+  individual-setup-build-test:
+    name: Individual Setup, Build and Test
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -33,6 +33,11 @@ jobs:
 
       - name: Build workspace
         uses: ./build
+        with:
+          distro: ${{ matrix.distro }}
+
+      - name: Test workspace
+        uses: ./test
         with:
           distro: ${{ matrix.distro }}
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,4 @@ runs:
 
     - uses: ichiro-its/ros2-ws-action/build@18f8d40805c2668f07b836763824d99bb6e33f9b
 
-    - shell: bash
-      run: |
-        source install/setup.bash
-        colcon test --event-handlers console_cohesion+ --pytest-with-coverage --return-code-on-test-failure
+    - uses: ichiro-its/ros2-ws-action/test@3aa0cc0847b20cb0b907952964d5c4e3594c1924

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -1,0 +1,13 @@
+name: ROS 2 Workspace Test
+description: Test packages in a ROS 2 workspace
+author: ICHIRO ITS
+branding:
+  icon: activity
+  color: gray-dark
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        source install/setup.bash
+        colcon test --event-handlers console_cohesion+ --pytest-with-coverage --return-code-on-test-failure


### PR DESCRIPTION
This pull request introduces the following changes:
- Introduces a "ROS 2 Workspace Test" sub-action for testing packages in a ROS 2 workspace.
- Uses the Test sub-action in the main action.
- Modifies the Individual Setup and Build job in the Test workflow to be Individual Setup, Build and Test job.

It closes #23.