### PR TITLE
Add `--ignore-src` in the Setup Sub-action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: ichiro-its/ros2-ws-action/setup@18f8d40805c2668f07b836763824d99bb6e33f9b
+    - uses: ichiro-its/ros2-ws-action/setup@34652cfbfafacc1dda0b7469d4e70a5214fd8bb9
       with:
         distro: ${{ inputs.distro }}
 

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -26,7 +26,7 @@ runs:
       run: |
         sudo rosdep init
         rosdep update
-        rosdep install -y --rosdistro ${{ inputs.distro }} --from-paths .
+        rosdep install -y --rosdistro ${{ inputs.distro }} --from-paths . --ignore-src
 
     - shell: bash
       run: |


### PR DESCRIPTION
This pull request adds the `--ignore-src` option to the Setup sub-action, which prevents `rosdep` from installing dependencies that are already included in the workspace. It closes #4.