### PR TITLE
  Do Not Specify Input Requirement If False in Action Files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,6 @@ branding:
 inputs:
   distro:
     description: The ROS 2 distribution to be used
-    required: false
     default: iron
 runs:
   using: composite

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -7,7 +7,6 @@ branding:
 inputs:
   distro:
     description: The ROS 2 distribution to be used
-    required: false
     default: iron
 runs:
   using: composite


### PR DESCRIPTION
This pull request resolves #51 by removing the `required: false` properties in the action inputs configuration of the action files.