### PR TITLE
Configure Dependabot Labels

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,4 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: [chore]


### PR DESCRIPTION
This pull request resolves #53 by simply configuring the label that will be used by Dependabot to `chore`.